### PR TITLE
Add comparison mode for multiple technologies

### DIFF
--- a/agents/mock_data.py
+++ b/agents/mock_data.py
@@ -1,9 +1,8 @@
 """
 Mock data for --dry-run mode.
 
-Provides a realistic TechAnalysisResult for Artificial Intelligence so the
-full pipeline (report generation, DOCX output, styling) can be tested
-without an API key.
+Provides realistic TechAnalysisResult instances so the full pipeline
+(report generation, DOCX output, styling) can be tested without an API key.
 """
 
 from .analyst import TechAnalysisResult, KeyPlayer, UseCase
@@ -205,3 +204,182 @@ AI_MOCK = TechAnalysisResult(
         "Supply chain vulnerabilities in AI chip manufacturing (TSMC dependency)",
     ],
 )
+
+
+BLOCKCHAIN_MOCK = TechAnalysisResult(
+    executive_summary=(
+        "Blockchain technology has matured beyond its cryptocurrency origins into a "
+        "foundational infrastructure layer for digital trust and decentralized applications. "
+        "The global blockchain market reached $27 billion in 2025, projected to grow to "
+        "$94 billion by 2030 at a CAGR of 28%. Enterprise adoption is accelerating in "
+        "financial services, supply chain management, and digital identity. Layer-2 scaling "
+        "solutions and cross-chain interoperability protocols have addressed earlier performance "
+        "limitations, enabling throughput of 10,000+ transactions per second. Regulatory clarity "
+        "in the EU (MiCA) and evolving US frameworks are reducing institutional hesitancy."
+    ),
+    technology_overview=(
+        "Blockchain is a distributed ledger technology that maintains an immutable, cryptographically "
+        "secured record of transactions across a network of nodes without a central authority. "
+        "Key architectural variants include public permissionless chains (Ethereum, Solana), "
+        "private permissioned networks (Hyperledger Fabric, R3 Corda), and hybrid approaches. "
+        "Smart contracts enable programmable, self-executing agreements. The technology stack "
+        "encompasses consensus mechanisms (PoS, PoA, BFT variants), Layer-2 solutions (rollups, "
+        "state channels), decentralized storage (IPFS, Arweave), and oracles (Chainlink) that "
+        "bridge on-chain and off-chain data."
+    ),
+    maturity_assessment=(
+        "Blockchain is in the early mainstream adoption phase. Cryptocurrency and DeFi have "
+        "crossed into mainstream awareness, while enterprise blockchain is transitioning from "
+        "pilot programs to production deployments. Tokenization of real-world assets (RWA) is "
+        "in the early growth stage, with major financial institutions launching tokenized bond "
+        "and fund products. Gartner placed blockchain on the 'Slope of Enlightenment' in 2024, "
+        "with enterprise use cases maturing faster than consumer applications. The technology is "
+        "production-ready for asset tokenization, trade finance, and supply chain provenance."
+    ),
+    market_landscape=(
+        "The global blockchain market was valued at $27 billion in 2025, with financial services "
+        "accounting for 38% of spending. North America leads with 35% market share, followed by "
+        "APAC at 32%. The tokenized assets market reached $12 billion in 2025 (excluding stablecoins) "
+        "and is projected to reach $16 trillion by 2030 according to BCG. Enterprise blockchain "
+        "platforms (Hyperledger, Ethereum Enterprise) grew 45% YoY. Stablecoin transaction volume "
+        "exceeded $10 trillion in 2024, surpassing Visa's payment volume."
+    ),
+    key_players=[
+        KeyPlayer(
+            name="Ethereum Foundation",
+            description="Maintains the Ethereum protocol, the dominant smart contract platform "
+                        "with $400B+ in total value locked across DeFi protocols.",
+            focus_area="Smart contracts, DeFi infrastructure, Layer-2 ecosystem",
+            market_position="Dominant platform for decentralized applications with ~60% DeFi market share",
+        ),
+        KeyPlayer(
+            name="Hyperledger (Linux Foundation)",
+            description="Open-source enterprise blockchain framework used by IBM, Walmart, and "
+                        "major supply chain consortia for permissioned networks.",
+            focus_area="Enterprise permissioned blockchains, supply chain, trade finance",
+            market_position="Leading enterprise blockchain framework with 300+ member organizations",
+        ),
+        KeyPlayer(
+            name="Chainlink Labs",
+            description="Provides decentralized oracle networks connecting blockchain smart contracts "
+                        "to real-world data, APIs, and payment systems.",
+            focus_area="Oracle networks, cross-chain interoperability, data feeds",
+            market_position="Dominant oracle provider securing $75B+ in DeFi value",
+        ),
+        KeyPlayer(
+            name="Ripple Labs",
+            description="Operates RippleNet for cross-border payments, partnering with 300+ financial "
+                        "institutions globally for real-time settlement.",
+            focus_area="Cross-border payments, institutional DeFi, CBDC infrastructure",
+            market_position="Leading blockchain payment network with institutional adoption focus",
+        ),
+        KeyPlayer(
+            name="ConsenSys",
+            description="Ethereum ecosystem builder behind MetaMask (30M+ users), Infura infrastructure, "
+                        "and enterprise solutions for major banks and governments.",
+            focus_area="Ethereum infrastructure, wallets, enterprise deployment tools",
+            market_position="Largest Ethereum infrastructure provider with developer ecosystem dominance",
+        ),
+    ],
+    use_cases=[
+        UseCase(
+            title="Tokenized Real-World Assets",
+            description="Converting traditional financial instruments (bonds, real estate, funds) into "
+                        "blockchain tokens for 24/7 trading, fractional ownership, and instant settlement. "
+                        "BlackRock's BUIDL fund reached $500M in tokenized assets within 6 months.",
+            industry="Financial Services",
+            impact_level="High",
+        ),
+        UseCase(
+            title="Supply Chain Provenance",
+            description="End-to-end tracking of goods from manufacturer to consumer using immutable "
+                        "blockchain records. Walmart uses Hyperledger to trace food products from farm "
+                        "to shelf in seconds instead of days.",
+            industry="Retail & Logistics",
+            impact_level="High",
+        ),
+        UseCase(
+            title="Decentralized Identity (DID)",
+            description="Self-sovereign identity systems giving individuals control over their digital "
+                        "credentials without relying on centralized providers. Used for KYC, healthcare "
+                        "records, and academic credentials across 40+ government pilot programs.",
+            industry="Government & Identity",
+            impact_level="Medium",
+        ),
+        UseCase(
+            title="Cross-Border Payments",
+            description="Near-instant international payments at a fraction of traditional correspondent "
+                        "banking costs. Stablecoins and blockchain rails reduce settlement from 3-5 days "
+                        "to under 10 seconds with fees below $0.01.",
+            industry="Banking & Payments",
+            impact_level="High",
+        ),
+        UseCase(
+            title="Carbon Credit Marketplaces",
+            description="Transparent tracking and trading of carbon credits on blockchain to prevent "
+                        "double-counting and fraud. Toucan Protocol has tokenized 20M+ tonnes of CO2 credits.",
+            industry="Energy & Environment",
+            impact_level="Medium",
+        ),
+    ],
+    strengths=[
+        "Immutability and transparency provide tamper-proof audit trails for compliance-heavy industries",
+        "Eliminates intermediaries, reducing transaction costs by 40-80% in cross-border payments",
+        "Smart contracts automate complex multi-party agreements without manual reconciliation",
+        "Cryptographic security with no single point of failure resistant to traditional cyberattacks",
+        "Programmable money and tokenization enable entirely new financial instruments and markets",
+    ],
+    limitations=[
+        "Scalability remains challenging for public chains — base layer throughput lags centralized systems",
+        "Energy consumption concerns persist for proof-of-work chains despite Ethereum's move to PoS",
+        "User experience is complex — private key management and gas fees deter mainstream adoption",
+        "Regulatory uncertainty in key markets (US) creates compliance risk for institutional adopters",
+        "Interoperability between different blockchain networks remains fragmented and technically complex",
+    ],
+    adoption_drivers=[
+        "Regulatory clarity (EU MiCA, Singapore MAS frameworks) reducing institutional compliance risk",
+        "Major financial institutions (BlackRock, JPMorgan, Goldman Sachs) launching tokenization products",
+        "Central Bank Digital Currency (CBDC) development by 130+ countries driving infrastructure investment",
+        "DeFi maturity with institutional-grade protocols offering 3-8% yields on tokenized assets",
+        "Supply chain disruptions post-COVID increasing demand for transparent provenance tracking",
+    ],
+    adoption_barriers=[
+        "Fragmented regulatory landscape across jurisdictions complicating global deployment",
+        "Shortage of blockchain developers — estimated 30,000 globally vs. millions of traditional developers",
+        "Legacy system integration complexity for enterprises with decades of existing IT infrastructure",
+        "Public perception still heavily associated with cryptocurrency speculation and fraud",
+        "Governance challenges in decentralized systems — protocol upgrades require broad consensus",
+    ],
+    future_outlook=(
+        "The next 3-5 years will see blockchain transition from a specialized technology to invisible "
+        "infrastructure underpinning financial markets, supply chains, and digital identity. Tokenization "
+        "of real-world assets is projected to reach $16 trillion by 2030, fundamentally restructuring "
+        "capital markets. CBDCs will launch in 20+ major economies, creating a new monetary layer built "
+        "on distributed ledger technology. Zero-knowledge proof technology will enable privacy-preserving "
+        "transactions at scale, addressing the privacy-transparency tradeoff. Cross-chain bridges and "
+        "universal standards (ERC-3643 for compliant tokens) will consolidate the fragmented ecosystem "
+        "into an interoperable web of value transfer."
+    ),
+    key_trends=[
+        "Real-world asset tokenization becoming the dominant institutional blockchain use case",
+        "Zero-knowledge proofs enabling privacy-preserving compliance and scalable computation",
+        "Central Bank Digital Currencies (CBDCs) driving government blockchain infrastructure investment",
+        "Account abstraction and social recovery improving end-user wallet experience",
+        "Decentralized Physical Infrastructure Networks (DePIN) bridging blockchain and IoT",
+        "Restaking and shared security models optimizing capital efficiency across protocols",
+        "Regulatory convergence with MiCA setting global standards for digital asset governance",
+    ],
+    risk_factors=[
+        "Regulatory crackdowns in major markets (US SEC enforcement) potentially stifling innovation",
+        "Smart contract vulnerabilities and DeFi exploits eroding trust — $1.8B lost in 2024 hacks",
+        "Concentration risk with Ethereum dominant — systemic risk if a critical vulnerability is found",
+        "Quantum computing threat to current cryptographic algorithms within the next 10-15 years",
+        "Geopolitical tensions driving blockchain balkanization and incompatible regional standards",
+    ],
+)
+
+
+COMPARISON_MOCKS = {
+    "Artificial Intelligence": AI_MOCK,
+    "Blockchain": BLOCKCHAIN_MOCK,
+}

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -9,6 +9,7 @@ import anthropic
 from agents.researcher import ResearchAgent
 from agents.analyst import AnalysisAgent, TechAnalysisResult
 from utils.report_generator import generate_docx_report
+from utils.comparison_report import generate_comparison_report
 
 
 class TechTrendOrchestrator:
@@ -64,6 +65,54 @@ class TechTrendOrchestrator:
         report_path = generate_docx_report(technology, analysis, self.output_dir)
         print(f"      Report saved: {report_path}")
 
+        return report_path
+
+    def run_comparison(self, technologies: list[str]) -> str:
+        """
+        Run the pipeline for multiple technologies and generate a comparison report.
+
+        Args:
+            technologies: List of 2-3 technology names to compare
+
+        Returns:
+            Absolute path to the generated comparison DOCX report
+        """
+        analyses = []
+        total = len(technologies)
+
+        for idx, tech in enumerate(technologies, 1):
+            print(f"\n{'='*60}")
+            print(f"  Analyzing {idx}/{total}: {tech}")
+            print(f"{'='*60}")
+
+            print(f"\n[1/2] Researching '{tech}' ...")
+            research_brief = self._researcher.research(tech)
+            word_count = len(research_brief.split())
+            print(f"      Research complete: {word_count:,} words collected.")
+
+            print(f"\n[2/2] Analyzing research data ...")
+            analysis = self._analyst.analyze(tech, research_brief)
+            print(f"      Analysis complete: "
+                  f"{len(analysis.key_players)} key players, "
+                  f"{len(analysis.use_cases)} use cases.")
+            analyses.append(analysis)
+
+        print(f"\n{'='*60}")
+        print(f"  Generating comparison report ...")
+        print(f"{'='*60}")
+
+        report_path = generate_comparison_report(technologies, analyses, self.output_dir)
+        print(f"      Report saved: {report_path}")
+
+        return report_path
+
+    def run_comparison_with_mock(
+        self, technologies: list[str], analyses: list[TechAnalysisResult],
+    ) -> str:
+        """Run comparison with pre-built analysis data (for --dry-run)."""
+        print(f"\n[DRY RUN] Generating comparison report for: {', '.join(technologies)}")
+        report_path = generate_comparison_report(technologies, analyses, self.output_dir)
+        print(f"      Report saved: {report_path}")
         return report_path
 
     def run_with_mock(self, technology: str, analysis: TechAnalysisResult) -> str:

--- a/main.py
+++ b/main.py
@@ -25,6 +25,12 @@ def main():
         help="Technology to analyze (e.g., 'Quantum Computing', 'Blockchain')",
     )
     parser.add_argument(
+        "--compare",
+        nargs="+",
+        metavar="TECH",
+        help="Compare 2-3 technologies side-by-side (e.g., --compare 'AI' 'Blockchain')",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Run with sample data (no API key needed)",
@@ -42,17 +48,33 @@ def main():
 
     args = parser.parse_args()
 
+    if args.compare and len(args.compare) < 2:
+        print("Error: --compare requires at least 2 technologies.")
+        sys.exit(1)
+    if args.compare and len(args.compare) > 3:
+        print("Error: --compare supports at most 3 technologies.")
+        sys.exit(1)
+
     if args.dry_run:
-        from agents.mock_data import AI_MOCK
+        from agents.mock_data import AI_MOCK, COMPARISON_MOCKS
         from agents.orchestrator import TechTrendOrchestrator
 
-        print("=" * 60)
-        print(f"  TECH TREND REPORT — DRY RUN")
-        print(f"  Technology: {args.technology}")
-        print("=" * 60)
-
         orch = TechTrendOrchestrator(output_dir=args.output)
-        report_path = orch.run_with_mock(args.technology, AI_MOCK)
+
+        if args.compare:
+            techs = args.compare
+            analyses = [COMPARISON_MOCKS.get(t, AI_MOCK) for t in techs]
+            print("=" * 60)
+            print(f"  TECH COMPARISON REPORT — DRY RUN")
+            print(f"  Technologies: {', '.join(techs)}")
+            print("=" * 60)
+            report_path = orch.run_comparison_with_mock(techs, analyses)
+        else:
+            print("=" * 60)
+            print(f"  TECH TREND REPORT — DRY RUN")
+            print(f"  Technology: {args.technology}")
+            print("=" * 60)
+            report_path = orch.run_with_mock(args.technology, AI_MOCK)
 
         print("\n" + "=" * 60)
         print(f"  Report ready: {report_path}")
@@ -67,17 +89,25 @@ def main():
 
         from agents.orchestrator import TechTrendOrchestrator
 
-        print("=" * 60)
-        print(f"  TECH TREND REPORT")
-        print(f"  Technology: {args.technology}")
-        print("=" * 60)
-
         orch = TechTrendOrchestrator(
             api_key=api_key,
             model=args.model,
             output_dir=args.output,
         )
-        report_path = orch.run(args.technology)
+
+        if args.compare:
+            techs = args.compare
+            print("=" * 60)
+            print(f"  TECH COMPARISON REPORT")
+            print(f"  Technologies: {', '.join(techs)}")
+            print("=" * 60)
+            report_path = orch.run_comparison(techs)
+        else:
+            print("=" * 60)
+            print(f"  TECH TREND REPORT")
+            print(f"  Technology: {args.technology}")
+            print("=" * 60)
+            report_path = orch.run(args.technology)
 
         print("\n" + "=" * 60)
         print(f"  Report ready: {report_path}")

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -1,0 +1,158 @@
+"""Tests for technology comparison mode."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from agents.analyst import TechAnalysisResult, KeyPlayer, UseCase
+from agents.mock_data import AI_MOCK, BLOCKCHAIN_MOCK, COMPARISON_MOCKS
+from utils.comparison_report import generate_comparison_report
+
+
+@pytest.fixture
+def minimal_analysis():
+    """Minimal TechAnalysisResult for testing."""
+    return TechAnalysisResult(
+        executive_summary="Summary text.",
+        technology_overview="Overview text.",
+        maturity_assessment="Maturity text.",
+        market_landscape="Market text.",
+        key_players=[
+            KeyPlayer(name="Company A", description="Desc",
+                      focus_area="Focus", market_position="Leading"),
+        ],
+        use_cases=[
+            UseCase(title="Use 1", description="Desc",
+                    industry="Tech", impact_level="High"),
+        ],
+        strengths=["Strength 1"],
+        limitations=["Limitation 1"],
+        adoption_drivers=["Driver 1"],
+        adoption_barriers=["Barrier 1"],
+        future_outlook="Outlook text.",
+        key_trends=["Trend 1"],
+        risk_factors=["Risk 1"],
+    )
+
+
+class TestComparisonMocks:
+    def test_comparison_mocks_has_ai(self):
+        assert "Artificial Intelligence" in COMPARISON_MOCKS
+
+    def test_comparison_mocks_has_blockchain(self):
+        assert "Blockchain" in COMPARISON_MOCKS
+
+    def test_blockchain_mock_is_valid(self):
+        assert isinstance(BLOCKCHAIN_MOCK, TechAnalysisResult)
+        assert len(BLOCKCHAIN_MOCK.key_players) >= 5
+        assert len(BLOCKCHAIN_MOCK.use_cases) >= 5
+        assert len(BLOCKCHAIN_MOCK.key_trends) >= 5
+
+    def test_blockchain_mock_content(self):
+        assert "Blockchain" in BLOCKCHAIN_MOCK.technology_overview
+        assert len(BLOCKCHAIN_MOCK.executive_summary) > 100
+
+
+class TestComparisonReport:
+    def test_generates_docx_file(self, tmp_path, minimal_analysis):
+        path = generate_comparison_report(
+            ["Tech A", "Tech B"],
+            [minimal_analysis, minimal_analysis],
+            output_dir=str(tmp_path),
+        )
+        assert os.path.isfile(path)
+        assert path.endswith(".docx")
+
+    def test_filename_contains_technologies(self, tmp_path, minimal_analysis):
+        path = generate_comparison_report(
+            ["Alpha", "Beta"],
+            [minimal_analysis, minimal_analysis],
+            output_dir=str(tmp_path),
+        )
+        basename = os.path.basename(path)
+        assert "alpha" in basename
+        assert "beta" in basename
+        assert "_vs_" in basename
+
+    def test_three_technologies(self, tmp_path, minimal_analysis):
+        path = generate_comparison_report(
+            ["A", "B", "C"],
+            [minimal_analysis, minimal_analysis, minimal_analysis],
+            output_dir=str(tmp_path),
+        )
+        assert os.path.isfile(path)
+
+    def test_with_real_mock_data(self, tmp_path):
+        path = generate_comparison_report(
+            ["Artificial Intelligence", "Blockchain"],
+            [AI_MOCK, BLOCKCHAIN_MOCK],
+            output_dir=str(tmp_path),
+        )
+        assert os.path.isfile(path)
+        assert os.path.getsize(path) > 10000
+
+    def test_creates_output_directory(self, tmp_path, minimal_analysis):
+        out = str(tmp_path / "nested" / "dir")
+        path = generate_comparison_report(
+            ["X", "Y"],
+            [minimal_analysis, minimal_analysis],
+            output_dir=out,
+        )
+        assert os.path.isfile(path)
+
+
+class TestOrchestratorComparison:
+    def test_run_comparison_with_mock(self, tmp_path):
+        from agents.orchestrator import TechTrendOrchestrator
+
+        orch = TechTrendOrchestrator(output_dir=str(tmp_path))
+        path = orch.run_comparison_with_mock(
+            ["AI", "Blockchain"],
+            [AI_MOCK, BLOCKCHAIN_MOCK],
+        )
+        assert os.path.isfile(path)
+
+    @patch("agents.orchestrator.ResearchAgent")
+    @patch("agents.orchestrator.AnalysisAgent")
+    def test_run_comparison_calls_agents(self, mock_analyst_cls, mock_researcher_cls, tmp_path):
+        from agents.orchestrator import TechTrendOrchestrator
+
+        mock_researcher = MagicMock()
+        mock_researcher.research.return_value = "Research data"
+        mock_researcher_cls.return_value = mock_researcher
+
+        mock_analyst = MagicMock()
+        mock_analyst.analyze.return_value = AI_MOCK
+        mock_analyst_cls.return_value = mock_analyst
+
+        orch = TechTrendOrchestrator(output_dir=str(tmp_path))
+        path = orch.run_comparison(["Tech A", "Tech B"])
+
+        assert mock_researcher.research.call_count == 2
+        assert mock_analyst.analyze.call_count == 2
+        assert os.path.isfile(path)
+
+
+class TestComparisonCLI:
+    def test_dry_run_compare(self, tmp_path):
+        result = subprocess.run(
+            [sys.executable, "main.py", "--dry-run",
+             "--compare", "Artificial Intelligence", "Blockchain",
+             "--output", str(tmp_path)],
+            capture_output=True, text=True,
+            cwd=os.path.dirname(os.path.dirname(__file__)),
+        )
+        assert result.returncode == 0
+        assert "COMPARISON" in result.stdout
+        assert "Report ready" in result.stdout
+
+    def test_compare_needs_two_techs(self):
+        result = subprocess.run(
+            [sys.executable, "main.py", "--dry-run", "--compare", "OnlyOne"],
+            capture_output=True, text=True,
+            cwd=os.path.dirname(os.path.dirname(__file__)),
+        )
+        assert result.returncode != 0

--- a/utils/comparison_report.py
+++ b/utils/comparison_report.py
@@ -99,7 +99,7 @@ def _build_cover(doc: Document, technologies: list[str]):
     doc.add_page_break()
 
 
-def _build_comparison_table(doc: Document, label: str, technologies: list[str],
+def _build_comparison_table(doc: Document, technologies: list[str],
                             analyses: list[TechAnalysisResult], field: str):
     """Build a side-by-side comparison table for a text field."""
     cols = len(technologies)

--- a/utils/comparison_report.py
+++ b/utils/comparison_report.py
@@ -1,0 +1,308 @@
+"""
+Comparison Report Generator — Side-by-side technology comparison DOCX report.
+
+Takes multiple TechAnalysisResult objects and produces a single report
+with comparison tables, strength/limitation matrices, and a combined outlook.
+"""
+
+import os
+from datetime import datetime
+from docx import Document
+from docx.shared import Inches, Pt, RGBColor
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.oxml.ns import qn
+from docx.oxml import OxmlElement
+
+from agents.analyst import TechAnalysisResult
+
+
+# ---------------------------------------------------------------------------
+# Color palette
+# ---------------------------------------------------------------------------
+COLOR_DARK = RGBColor(0x1A, 0x37, 0x6C)
+COLOR_ACCENT = RGBColor(0x2E, 0x6D, 0xB4)
+COLOR_WHITE = RGBColor(0xFF, 0xFF, 0xFF)
+COLOR_LIGHT_BG = "F0F5FF"
+COLOR_ALT_BG = "FFFFFF"
+
+# Per-technology accent colors for headers
+TECH_COLORS = ["1A6C3C", "1A376C", "6C1A3C", "3C1A6C"]
+
+
+def _set_cell_bg(cell, hex_color: str):
+    tc = cell._tc
+    tcPr = tc.get_or_add_tcPr()
+    shd = OxmlElement("w:shd")
+    shd.set(qn("w:val"), "clear")
+    shd.set(qn("w:color"), "auto")
+    shd.set(qn("w:fill"), hex_color)
+    tcPr.append(shd)
+
+
+def _add_heading(doc: Document, text: str, level: int = 1):
+    para = doc.add_heading(text, level=level)
+    run = para.runs[0]
+    run.font.color.rgb = COLOR_DARK
+    run.font.bold = True
+    if level == 1:
+        run.font.size = Pt(16)
+    elif level == 2:
+        run.font.size = Pt(13)
+        run.font.color.rgb = COLOR_ACCENT
+    para.paragraph_format.space_before = Pt(14)
+    para.paragraph_format.space_after = Pt(4)
+
+
+def _add_hr(doc: Document):
+    para = doc.add_paragraph()
+    pPr = para._p.get_or_add_pPr()
+    pBdr = OxmlElement("w:pBdr")
+    bottom = OxmlElement("w:bottom")
+    bottom.set(qn("w:val"), "single")
+    bottom.set(qn("w:sz"), "6")
+    bottom.set(qn("w:space"), "1")
+    bottom.set(qn("w:color"), "2E6DB4")
+    pBdr.append(bottom)
+    pPr.append(pBdr)
+
+
+def _build_cover(doc: Document, technologies: list[str]):
+    doc.add_paragraph()
+    doc.add_paragraph()
+
+    title = doc.add_paragraph()
+    title.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = title.add_run("TECHNOLOGY COMPARISON REPORT")
+    run.font.size = Pt(28)
+    run.font.bold = True
+    run.font.color.rgb = COLOR_DARK
+
+    doc.add_paragraph()
+
+    tech_para = doc.add_paragraph()
+    tech_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = tech_para.add_run(" vs ".join(technologies))
+    run.font.size = Pt(20)
+    run.font.bold = True
+    run.font.color.rgb = COLOR_ACCENT
+
+    doc.add_paragraph()
+    doc.add_paragraph()
+
+    date_para = doc.add_paragraph()
+    date_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = date_para.add_run(f"Generated: {datetime.now().strftime('%B %d, %Y')}")
+    run.font.size = Pt(11)
+    run.font.color.rgb = RGBColor(0x6B, 0x72, 0x80)
+    run.font.italic = True
+
+    doc.add_page_break()
+
+
+def _build_comparison_table(doc: Document, label: str, technologies: list[str],
+                            analyses: list[TechAnalysisResult], field: str):
+    """Build a side-by-side comparison table for a text field."""
+    cols = len(technologies)
+    table = doc.add_table(rows=2, cols=cols)
+    table.style = "Table Grid"
+    table.autofit = False
+
+    col_width = Inches(6.0 / cols)
+    for col in table.columns:
+        for cell in col.cells:
+            cell.width = col_width
+
+    for i, tech in enumerate(technologies):
+        cell = table.rows[0].cells[i]
+        color = TECH_COLORS[i % len(TECH_COLORS)]
+        _set_cell_bg(cell, color)
+        para = cell.paragraphs[0]
+        para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        run = para.add_run(tech)
+        run.font.bold = True
+        run.font.size = Pt(10)
+        run.font.color.rgb = COLOR_WHITE
+
+    for i, analysis in enumerate(analyses):
+        cell = table.rows[1].cells[i]
+        _set_cell_bg(cell, COLOR_LIGHT_BG if i % 2 == 0 else COLOR_ALT_BG)
+        text = getattr(analysis, field, "")
+        para = cell.paragraphs[0]
+        run = para.add_run(text)
+        run.font.size = Pt(9.5)
+
+    doc.add_paragraph()
+
+
+def _build_list_comparison(doc: Document, technologies: list[str],
+                           analyses: list[TechAnalysisResult], field: str):
+    """Build a side-by-side comparison of list fields."""
+    cols = len(technologies)
+    table = doc.add_table(rows=2, cols=cols)
+    table.style = "Table Grid"
+    table.autofit = False
+
+    col_width = Inches(6.0 / cols)
+    for col in table.columns:
+        for cell in col.cells:
+            cell.width = col_width
+
+    for i, tech in enumerate(technologies):
+        cell = table.rows[0].cells[i]
+        color = TECH_COLORS[i % len(TECH_COLORS)]
+        _set_cell_bg(cell, color)
+        para = cell.paragraphs[0]
+        para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        run = para.add_run(tech)
+        run.font.bold = True
+        run.font.size = Pt(10)
+        run.font.color.rgb = COLOR_WHITE
+
+    for i, analysis in enumerate(analyses):
+        cell = table.rows[1].cells[i]
+        _set_cell_bg(cell, COLOR_LIGHT_BG if i % 2 == 0 else COLOR_ALT_BG)
+        items = getattr(analysis, field, [])
+        for item in items:
+            para = cell.add_paragraph(style="List Bullet")
+            para.paragraph_format.left_indent = Inches(0.15)
+            run = para.add_run(item)
+            run.font.size = Pt(9)
+
+    doc.add_paragraph()
+
+
+def _build_key_player_comparison(doc: Document, technologies: list[str],
+                                 analyses: list[TechAnalysisResult]):
+    """Summary table of top players per technology."""
+    headers = ["Technology", "Player", "Focus Area", "Market Position"]
+    rows_data = []
+    for tech, analysis in zip(technologies, analyses):
+        for player in analysis.key_players[:3]:
+            rows_data.append((tech, player.name, player.focus_area, player.market_position))
+
+    table = doc.add_table(rows=1 + len(rows_data), cols=4)
+    table.style = "Table Grid"
+    table.autofit = False
+    widths = [Inches(1.3), Inches(1.3), Inches(1.8), Inches(1.8)]
+    for i, w in enumerate(widths):
+        for row in table.rows:
+            row.cells[i].width = w
+
+    for i, h in enumerate(headers):
+        cell = table.rows[0].cells[i]
+        _set_cell_bg(cell, "1A376C")
+        para = cell.paragraphs[0]
+        para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+        run = para.add_run(h)
+        run.font.bold = True
+        run.font.size = Pt(10)
+        run.font.color.rgb = COLOR_WHITE
+
+    for row_idx, (tech, name, focus, position) in enumerate(rows_data):
+        row = table.rows[row_idx + 1]
+        bg = COLOR_LIGHT_BG if row_idx % 2 == 0 else COLOR_ALT_BG
+        for col_idx, value in enumerate([tech, name, focus, position]):
+            cell = row.cells[col_idx]
+            _set_cell_bg(cell, bg)
+            para = cell.paragraphs[0]
+            run = para.add_run(value)
+            run.font.size = Pt(9)
+            if col_idx <= 1:
+                run.font.bold = True
+
+    doc.add_paragraph()
+
+
+def generate_comparison_report(
+    technologies: list[str],
+    analyses: list[TechAnalysisResult],
+    output_dir: str = "output",
+) -> str:
+    """
+    Generate a side-by-side technology comparison DOCX report.
+
+    Args:
+        technologies: List of technology names
+        analyses:     Corresponding list of TechAnalysisResult objects
+        output_dir:   Output directory
+
+    Returns:
+        Absolute path to the generated .docx file
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    doc = Document()
+
+    section = doc.sections[0]
+    section.top_margin = Inches(0.8)
+    section.bottom_margin = Inches(0.8)
+    section.left_margin = Inches(0.8)
+    section.right_margin = Inches(0.8)
+
+    style = doc.styles["Normal"]
+    style.font.size = Pt(10.5)
+    style.font.name = "Calibri"
+
+    _build_cover(doc, technologies)
+
+    # Executive Summary comparison
+    _add_heading(doc, "Executive Summary Comparison")
+    _add_hr(doc)
+    _build_comparison_table(doc, technologies, analyses, "executive_summary")
+
+    # Maturity comparison
+    _add_heading(doc, "Maturity Assessment")
+    _add_hr(doc)
+    _build_comparison_table(doc, technologies, analyses, "maturity_assessment")
+
+    # Market Landscape
+    _add_heading(doc, "Market Landscape")
+    _add_hr(doc)
+    _build_comparison_table(doc, technologies, analyses, "market_landscape")
+
+    # Key Players
+    _add_heading(doc, "Key Players Comparison")
+    _add_hr(doc)
+    _build_key_player_comparison(doc, technologies, analyses)
+
+    # Strengths comparison
+    _add_heading(doc, "Strengths")
+    _add_hr(doc)
+    _build_list_comparison(doc, technologies, analyses, "strengths")
+
+    # Limitations comparison
+    _add_heading(doc, "Limitations")
+    _add_hr(doc)
+    _build_list_comparison(doc, technologies, analyses, "limitations")
+
+    # Key Trends
+    _add_heading(doc, "Key Trends")
+    _add_hr(doc)
+    _build_list_comparison(doc, technologies, analyses, "key_trends")
+
+    # Risk Factors
+    _add_heading(doc, "Risk Factors")
+    _add_hr(doc)
+    _build_list_comparison(doc, technologies, analyses, "risk_factors")
+
+    # Future Outlook
+    _add_heading(doc, "Future Outlook")
+    _add_hr(doc)
+    _build_comparison_table(doc, technologies, analyses, "future_outlook")
+
+    # Footer
+    doc.add_paragraph()
+    footer = doc.add_paragraph()
+    footer.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    run = footer.add_run(
+        f"Generated by Tech Trend Analysis System  •  {datetime.now().strftime('%Y-%m-%d')}"
+    )
+    run.font.size = Pt(8.5)
+    run.font.italic = True
+    run.font.color.rgb = RGBColor(0x9C, 0xA3, 0xAF)
+
+    safe = "_vs_".join(t.lower().replace(" ", "_")[:20] for t in technologies)
+    filename = f"tech_comparison_{safe}_{datetime.now().strftime('%Y%m%d')}.docx"
+    filepath = os.path.join(output_dir, filename)
+    doc.save(filepath)
+
+    return os.path.abspath(filepath)


### PR DESCRIPTION
## Summary
- New `--compare` flag accepts 2-3 technologies for side-by-side analysis
- Generates a single DOCX report with comparison tables for executive summaries, maturity, market landscape, key players, strengths/limitations, trends, risk factors, and future outlook
- Includes Blockchain mock data for `--dry-run` testing
- Orchestrator runs research and analysis sequentially per technology, then builds combined report

## Test plan
- [x] 13 new tests covering mock data, report generation, orchestrator, and CLI
- [x] Full test suite passes (76 tests)
- [x] `python main.py --dry-run --compare "Artificial Intelligence" "Blockchain"` produces valid DOCX

Closes #1