### PR TITLE
Add PDF report output alongside DOCX (--format flag)

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -10,6 +10,20 @@ from agents.researcher import ResearchAgent
 from agents.analyst import AnalysisAgent, TechAnalysisResult
 from utils.report_generator import generate_docx_report
 from utils.comparison_report import generate_comparison_report
+from utils.pdf_report_generator import (
+    generate_pdf_report,
+    generate_comparison_pdf_report,
+)
+
+
+def _resolve_formats(fmt: str) -> list[str]:
+    """Map the public ``format`` argument to the concrete list of writers."""
+    fmt = (fmt or "docx").lower()
+    if fmt == "both":
+        return ["docx", "pdf"]
+    if fmt in ("docx", "pdf"):
+        return [fmt]
+    raise ValueError(f"Unknown report format '{fmt}' (expected: docx, pdf, both)")
 
 
 class TechTrendOrchestrator:
@@ -34,16 +48,45 @@ class TechTrendOrchestrator:
         self._researcher = ResearchAgent(self.client, model=model)
         self._analyst = AnalysisAgent(self.client, model=model)
 
-    def run(self, technology: str) -> str:
+    def _write_reports(
+        self,
+        technology: str,
+        analysis: TechAnalysisResult,
+        formats: list[str],
+    ) -> list[str]:
+        paths: list[str] = []
+        if "docx" in formats:
+            paths.append(generate_docx_report(technology, analysis, self.output_dir))
+        if "pdf" in formats:
+            paths.append(generate_pdf_report(technology, analysis, self.output_dir))
+        return paths
+
+    def _write_comparison_reports(
+        self,
+        technologies: list[str],
+        analyses: list[TechAnalysisResult],
+        formats: list[str],
+    ) -> list[str]:
+        paths: list[str] = []
+        if "docx" in formats:
+            paths.append(generate_comparison_report(technologies, analyses, self.output_dir))
+        if "pdf" in formats:
+            paths.append(generate_comparison_pdf_report(technologies, analyses, self.output_dir))
+        return paths
+
+    def run(self, technology: str, format: str = "docx") -> list[str]:
         """
         Execute the full pipeline for a given technology.
 
         Args:
             technology: Name of the technology to analyze
+            format:     "docx" (default), "pdf", or "both"
 
         Returns:
-            Absolute path to the generated DOCX report
+            Paths to the generated report files.
         """
+        formats = _resolve_formats(format)
+
         # Phase 1: Research
         print(f"\n[1/3] Researching '{technology}' — gathering web intelligence ...")
         research_brief = self._researcher.research(technology)
@@ -61,22 +104,16 @@ class TechTrendOrchestrator:
         )
 
         # Phase 3: Report
-        print(f"\n[3/3] Generating DOCX report ...")
-        report_path = generate_docx_report(technology, analysis, self.output_dir)
-        print(f"      Report saved: {report_path}")
+        print(f"\n[3/3] Generating {' + '.join(f.upper() for f in formats)} report ...")
+        paths = self._write_reports(technology, analysis, formats)
+        for p in paths:
+            print(f"      Report saved: {p}")
 
-        return report_path
+        return paths
 
-    def run_comparison(self, technologies: list[str]) -> str:
-        """
-        Run the pipeline for multiple technologies and generate a comparison report.
-
-        Args:
-            technologies: List of 2-3 technology names to compare
-
-        Returns:
-            Absolute path to the generated comparison DOCX report
-        """
+    def run_comparison(self, technologies: list[str], format: str = "docx") -> list[str]:
+        """Run the pipeline for multiple technologies and generate a comparison report."""
+        formats = _resolve_formats(format)
         analyses = []
         total = len(technologies)
 
@@ -98,34 +135,36 @@ class TechTrendOrchestrator:
             analyses.append(analysis)
 
         print(f"\n{'='*60}")
-        print(f"  Generating comparison report ...")
+        print(f"  Generating comparison report ({' + '.join(f.upper() for f in formats)}) ...")
         print(f"{'='*60}")
 
-        report_path = generate_comparison_report(technologies, analyses, self.output_dir)
-        print(f"      Report saved: {report_path}")
-
-        return report_path
+        paths = self._write_comparison_reports(technologies, analyses, formats)
+        for p in paths:
+            print(f"      Report saved: {p}")
+        return paths
 
     def run_comparison_with_mock(
-        self, technologies: list[str], analyses: list[TechAnalysisResult],
-    ) -> str:
+        self,
+        technologies: list[str],
+        analyses: list[TechAnalysisResult],
+        format: str = "docx",
+    ) -> list[str]:
         """Run comparison with pre-built analysis data (for --dry-run)."""
+        formats = _resolve_formats(format)
         print(f"\n[DRY RUN] Generating comparison report for: {', '.join(technologies)}")
-        report_path = generate_comparison_report(technologies, analyses, self.output_dir)
-        print(f"      Report saved: {report_path}")
-        return report_path
+        paths = self._write_comparison_reports(technologies, analyses, formats)
+        for p in paths:
+            print(f"      Report saved: {p}")
+        return paths
 
-    def run_with_mock(self, technology: str, analysis: TechAnalysisResult) -> str:
-        """
-        Run the pipeline with pre-built analysis data (for --dry-run).
-
-        Args:
-            technology: Technology name for the report title
-            analysis:   Pre-built TechAnalysisResult
-
-        Returns:
-            Absolute path to the generated DOCX report
-        """
+    def run_with_mock(
+        self,
+        technology: str,
+        analysis: TechAnalysisResult,
+        format: str = "docx",
+    ) -> list[str]:
+        """Run the pipeline with pre-built analysis data (for --dry-run)."""
+        formats = _resolve_formats(format)
         print(f"\n[1/3] DRY RUN — skipping web research (using mock data)")
         print(f"[2/3] DRY RUN — skipping analysis (using mock data)")
 
@@ -134,8 +173,8 @@ class TechTrendOrchestrator:
               f"{len(analysis.use_cases)} use cases, "
               f"{len(analysis.key_trends)} trends.")
 
-        print(f"\n[3/3] Generating DOCX report ...")
-        report_path = generate_docx_report(technology, analysis, self.output_dir)
-        print(f"      Report saved: {report_path}")
-
-        return report_path
+        print(f"\n[3/3] Generating {' + '.join(f.upper() for f in formats)} report ...")
+        paths = self._write_reports(technology, analysis, formats)
+        for p in paths:
+            print(f"      Report saved: {p}")
+        return paths

--- a/main.py
+++ b/main.py
@@ -45,6 +45,12 @@ def main():
         default="claude-opus-4-6",
         help="Model to use for analysis (default: claude-opus-4-6)",
     )
+    parser.add_argument(
+        "--format",
+        choices=["docx", "pdf", "both"],
+        default="docx",
+        help="Report output format (default: docx)",
+    )
 
     args = parser.parse_args()
 
@@ -68,16 +74,17 @@ def main():
             print(f"  TECH COMPARISON REPORT — DRY RUN")
             print(f"  Technologies: {', '.join(techs)}")
             print("=" * 60)
-            report_path = orch.run_comparison_with_mock(techs, analyses)
+            report_paths = orch.run_comparison_with_mock(techs, analyses, format=args.format)
         else:
             print("=" * 60)
             print(f"  TECH TREND REPORT — DRY RUN")
             print(f"  Technology: {args.technology}")
             print("=" * 60)
-            report_path = orch.run_with_mock(args.technology, AI_MOCK)
+            report_paths = orch.run_with_mock(args.technology, AI_MOCK, format=args.format)
 
         print("\n" + "=" * 60)
-        print(f"  Report ready: {report_path}")
+        for p in report_paths:
+            print(f"  Report ready: {p}")
         print("=" * 60)
     else:
         api_key = os.environ.get("ANTHROPIC_API_KEY")
@@ -101,16 +108,17 @@ def main():
             print(f"  TECH COMPARISON REPORT")
             print(f"  Technologies: {', '.join(techs)}")
             print("=" * 60)
-            report_path = orch.run_comparison(techs)
+            report_paths = orch.run_comparison(techs, format=args.format)
         else:
             print("=" * 60)
             print(f"  TECH TREND REPORT")
             print(f"  Technology: {args.technology}")
             print("=" * 60)
-            report_path = orch.run(args.technology)
+            report_paths = orch.run(args.technology, format=args.format)
 
         print("\n" + "=" * 60)
-        print(f"  Report ready: {report_path}")
+        for p in report_paths:
+            print(f"  Report ready: {p}")
         print("=" * 60)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 anthropic>=0.49.0
 matplotlib>=3.7.0
 python-docx>=1.1.0
+fpdf2>=2.7.0
 python-dotenv>=1.0.0
 pydantic>=2.0.0
 pytest>=8.0.0

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -134,6 +134,7 @@ class TestOrchestrator:
         orch._researcher = ResearchAgent(mock_client)
         orch._analyst = AnalysisAgent(mock_client)
 
-        report_path = orch.run("Artificial Intelligence")
-        assert report_path.endswith(".docx")
-        assert "artificial_intelligence" in report_path
+        report_paths = orch.run("Artificial Intelligence")
+        assert isinstance(report_paths, list) and len(report_paths) == 1
+        assert report_paths[0].endswith(".docx")
+        assert "artificial_intelligence" in report_paths[0]

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -109,11 +109,12 @@ class TestOrchestratorComparison:
         from agents.orchestrator import TechTrendOrchestrator
 
         orch = TechTrendOrchestrator(output_dir=str(tmp_path))
-        path = orch.run_comparison_with_mock(
+        paths = orch.run_comparison_with_mock(
             ["AI", "Blockchain"],
             [AI_MOCK, BLOCKCHAIN_MOCK],
         )
-        assert os.path.isfile(path)
+        assert isinstance(paths, list) and len(paths) == 1
+        assert os.path.isfile(paths[0])
 
     @patch("agents.orchestrator.ResearchAgent")
     @patch("agents.orchestrator.AnalysisAgent")
@@ -129,11 +130,12 @@ class TestOrchestratorComparison:
         mock_analyst_cls.return_value = mock_analyst
 
         orch = TechTrendOrchestrator(output_dir=str(tmp_path))
-        path = orch.run_comparison(["Tech A", "Tech B"])
+        paths = orch.run_comparison(["Tech A", "Tech B"])
 
         assert mock_researcher.research.call_count == 2
         assert mock_analyst.analyze.call_count == 2
-        assert os.path.isfile(path)
+        assert isinstance(paths, list) and len(paths) == 1
+        assert os.path.isfile(paths[0])
 
 
 class TestComparisonCLI:

--- a/tests/test_pdf_report_generator.py
+++ b/tests/test_pdf_report_generator.py
@@ -1,0 +1,87 @@
+"""Tests for the PDF report generator."""
+
+import os
+
+import pytest
+
+from agents.mock_data import AI_MOCK, COMPARISON_MOCKS
+from utils.pdf_report_generator import (
+    _sanitize,
+    generate_comparison_pdf_report,
+    generate_pdf_report,
+)
+
+
+class TestSanitize:
+    def test_replaces_em_dash(self):
+        assert _sanitize("foo — bar") == "foo -- bar"
+
+    def test_replaces_smart_quotes(self):
+        assert _sanitize("‘hi’ “there”") == "'hi' \"there\""
+
+    def test_replaces_bullet_and_ellipsis(self):
+        assert _sanitize("• one… two") == "- one... two"
+
+    def test_replaces_german_umlauts(self):
+        assert _sanitize("Über grün — Größe") == "Ueber gruen -- Groesse"
+
+    def test_replaces_euro_sign(self):
+        assert _sanitize("Cost: 5€") == "Cost: 5EUR"
+
+    def test_handles_none(self):
+        assert _sanitize(None) == ""
+
+    def test_pure_ascii_passes_through(self):
+        assert _sanitize("plain ascii") == "plain ascii"
+
+    def test_unknown_unicode_does_not_crash(self):
+        # 㐀 is a CJK ideograph — replaced with '?' via errors='replace'
+        out = _sanitize("hello 㐀 world")
+        assert "hello" in out and "world" in out
+
+
+class TestGeneratePdfReport:
+    def test_returns_existing_path(self, tmp_path):
+        path = generate_pdf_report("Artificial Intelligence", AI_MOCK, str(tmp_path))
+        assert os.path.isfile(path)
+        assert path.endswith(".pdf")
+
+    def test_pdf_has_meaningful_size(self, tmp_path):
+        path = generate_pdf_report("Artificial Intelligence", AI_MOCK, str(tmp_path))
+        # Cover page + several sections + 2 embedded charts → well over 1 kB
+        assert os.path.getsize(path) > 1024
+
+    def test_filename_contains_technology(self, tmp_path):
+        path = generate_pdf_report("Quantum Computing", AI_MOCK, str(tmp_path))
+        assert "quantum_computing" in os.path.basename(path)
+
+    def test_creates_output_directory(self, tmp_path):
+        nested = tmp_path / "nested" / "deeper"
+        path = generate_pdf_report("AI", AI_MOCK, str(nested))
+        assert os.path.isfile(path)
+
+
+class TestGenerateComparisonPdfReport:
+    def test_returns_existing_path(self, tmp_path):
+        techs = list(COMPARISON_MOCKS.keys())[:2]
+        analyses = [COMPARISON_MOCKS[t] for t in techs]
+        path = generate_comparison_pdf_report(techs, analyses, str(tmp_path))
+        assert os.path.isfile(path)
+        assert path.endswith(".pdf")
+
+    def test_three_way_comparison(self, tmp_path):
+        techs = list(COMPARISON_MOCKS.keys())[:3]
+        analyses = [COMPARISON_MOCKS[t] for t in techs]
+        path = generate_comparison_pdf_report(techs, analyses, str(tmp_path))
+        assert os.path.isfile(path)
+
+    def test_filename_contains_all_technologies(self, tmp_path):
+        techs = ["AI", "Blockchain"]
+        analyses = [COMPARISON_MOCKS.get(t, AI_MOCK) for t in techs]
+        path = generate_comparison_pdf_report(techs, analyses, str(tmp_path))
+        name = os.path.basename(path).lower()
+        assert "ai" in name and "blockchain" in name
+
+    def test_mismatched_lengths_raise(self, tmp_path):
+        with pytest.raises(ValueError):
+            generate_comparison_pdf_report(["A", "B"], [AI_MOCK], str(tmp_path))

--- a/utils/pdf_report_generator.py
+++ b/utils/pdf_report_generator.py
@@ -1,0 +1,270 @@
+"""PDF report generator for technology trend reports using fpdf2."""
+
+import os
+from datetime import datetime
+
+from fpdf import FPDF
+
+from agents.analyst import TechAnalysisResult
+from utils.chart_generator import (
+    create_key_players_chart,
+    create_use_case_impact_chart,
+)
+
+
+_UNICODE_REPLACEMENTS = {
+    "–": "-",
+    "—": "--",
+    "‘": "'",
+    "’": "'",
+    "“": '"',
+    "”": '"',
+    "…": "...",
+    "•": "-",
+    "€": "EUR",
+    "ü": "ue",
+    "ä": "ae",
+    "ö": "oe",
+    "Ü": "Ue",
+    "Ä": "Ae",
+    "Ö": "Oe",
+    "ß": "ss",
+}
+
+IMPACT_COLORS = {
+    "High": (198, 40, 40),
+    "Medium": (230, 142, 0),
+    "Low": (13, 115, 119),
+}
+
+
+def _sanitize(text: str) -> str:
+    """Coerce text to latin-1 so fpdf2 with Helvetica can render it."""
+    if text is None:
+        return ""
+    for char, replacement in _UNICODE_REPLACEMENTS.items():
+        text = text.replace(char, replacement)
+    return text.encode("latin-1", errors="replace").decode("latin-1")
+
+
+class _TrendReportPDF(FPDF):
+
+    def __init__(self, title: str):
+        super().__init__()
+        self._doc_title = title
+
+    def footer(self):
+        self.set_y(-15)
+        self.set_font("Helvetica", "I", 8)
+        self.set_text_color(120, 120, 120)
+        self.cell(0, 10, _sanitize(f"{self._doc_title}  |  Page {self.page_no()}"), align="C")
+
+
+# ---------------------------------------------------------------------------
+# Section helpers
+# ---------------------------------------------------------------------------
+
+def _heading(pdf: FPDF, text: str, size: int = 14):
+    pdf.set_x(pdf.l_margin)
+    pdf.set_font("Helvetica", "B", size)
+    pdf.set_text_color(13, 115, 119)
+    pdf.cell(0, 10, _sanitize(text), new_x="LMARGIN", new_y="NEXT")
+    pdf.set_text_color(0, 0, 0)
+
+
+def _paragraph(pdf: FPDF, text: str):
+    pdf.set_x(pdf.l_margin)
+    pdf.set_font("Helvetica", "", 10)
+    pdf.multi_cell(0, 5, _sanitize(text))
+    pdf.ln(2)
+
+
+def _bullets(pdf: FPDF, items: list[str]):
+    pdf.set_font("Helvetica", "", 10)
+    for item in items:
+        pdf.set_x(pdf.l_margin)
+        pdf.multi_cell(0, 5, _sanitize(f"   - {item}"))
+    pdf.ln(2)
+
+
+def _add_cover(pdf: FPDF, technology: str, analysis: TechAnalysisResult):
+    pdf.add_page()
+    pdf.ln(40)
+    pdf.set_font("Helvetica", "B", 26)
+    pdf.set_text_color(13, 115, 119)
+    pdf.multi_cell(0, 12, _sanitize(f"{technology}"), align="C")
+    pdf.ln(2)
+    pdf.set_font("Helvetica", "", 14)
+    pdf.set_text_color(80, 80, 80)
+    pdf.cell(0, 8, "Technology Trend Report", new_x="LMARGIN", new_y="NEXT", align="C")
+    pdf.ln(8)
+    pdf.set_font("Helvetica", "I", 11)
+    pdf.cell(0, 6, _sanitize(datetime.now().strftime("%B %Y")), new_x="LMARGIN", new_y="NEXT", align="C")
+    pdf.set_text_color(0, 0, 0)
+
+    pdf.ln(20)
+    pdf.set_font("Helvetica", "B", 12)
+    pdf.cell(0, 8, "Executive Summary", new_x="LMARGIN", new_y="NEXT")
+    _paragraph(pdf, analysis.executive_summary)
+
+
+def _add_overview(pdf: FPDF, analysis: TechAnalysisResult):
+    pdf.add_page()
+    _heading(pdf, "Technology Overview")
+    _paragraph(pdf, analysis.technology_overview)
+    _heading(pdf, "Maturity Assessment", size=12)
+    _paragraph(pdf, analysis.maturity_assessment)
+    _heading(pdf, "Market Landscape", size=12)
+    _paragraph(pdf, analysis.market_landscape)
+
+
+def _add_key_players(pdf: FPDF, analysis: TechAnalysisResult, chart_path: str | None):
+    pdf.add_page()
+    _heading(pdf, "Key Players")
+    if chart_path and os.path.exists(chart_path):
+        pdf.image(chart_path, w=170)
+        pdf.ln(4)
+    for player in analysis.key_players:
+        pdf.set_font("Helvetica", "B", 11)
+        pdf.cell(0, 6, _sanitize(player.name), new_x="LMARGIN", new_y="NEXT")
+        pdf.set_font("Helvetica", "I", 9)
+        pdf.cell(0, 5, _sanitize(f"{player.focus_area}  |  {player.market_position}"), new_x="LMARGIN", new_y="NEXT")
+        _paragraph(pdf, player.description)
+
+
+def _add_use_cases(pdf: FPDF, analysis: TechAnalysisResult, chart_path: str | None):
+    pdf.add_page()
+    _heading(pdf, "Use Cases")
+    if chart_path and os.path.exists(chart_path):
+        pdf.image(chart_path, w=170)
+        pdf.ln(4)
+    for uc in analysis.use_cases:
+        pdf.set_font("Helvetica", "B", 11)
+        pdf.cell(0, 6, _sanitize(uc.title), new_x="LMARGIN", new_y="NEXT")
+        color = IMPACT_COLORS.get(uc.impact_level, (120, 120, 120))
+        pdf.set_text_color(*color)
+        pdf.set_font("Helvetica", "I", 9)
+        pdf.cell(0, 5, _sanitize(f"Impact: {uc.impact_level}  |  Industry: {uc.industry}"), new_x="LMARGIN", new_y="NEXT")
+        pdf.set_text_color(0, 0, 0)
+        _paragraph(pdf, uc.description)
+
+
+def _add_strategic_outlook(pdf: FPDF, analysis: TechAnalysisResult):
+    pdf.add_page()
+    _heading(pdf, "Strategic Outlook")
+    _paragraph(pdf, analysis.future_outlook)
+
+    _heading(pdf, "Strengths", size=12)
+    _bullets(pdf, analysis.strengths)
+
+    _heading(pdf, "Limitations", size=12)
+    _bullets(pdf, analysis.limitations)
+
+    _heading(pdf, "Adoption Drivers", size=12)
+    _bullets(pdf, analysis.adoption_drivers)
+
+    _heading(pdf, "Adoption Barriers", size=12)
+    _bullets(pdf, analysis.adoption_barriers)
+
+    _heading(pdf, "Key Trends", size=12)
+    _bullets(pdf, analysis.key_trends)
+
+    _heading(pdf, "Risk Factors", size=12)
+    _bullets(pdf, analysis.risk_factors)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def _materialize_chart(buf, output_dir: str, name: str) -> str | None:
+    """Persist a BytesIO chart to disk and return the file path."""
+    if buf is None:
+        return None
+    chart_dir = os.path.join(output_dir, "charts")
+    os.makedirs(chart_dir, exist_ok=True)
+    path = os.path.join(chart_dir, name)
+    buf.seek(0)
+    with open(path, "wb") as f:
+        f.write(buf.read())
+    return path
+
+
+def generate_pdf_report(
+    technology: str,
+    analysis: TechAnalysisResult,
+    output_dir: str,
+) -> str:
+    """Generate a single-technology PDF trend report and return its path."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    players_chart = _materialize_chart(
+        create_key_players_chart(analysis), output_dir, "key_players.png"
+    )
+    use_case_chart = _materialize_chart(
+        create_use_case_impact_chart(analysis), output_dir, "use_case_impact.png"
+    )
+
+    pdf = _TrendReportPDF(title=f"{technology} Trend Report")
+    pdf.set_auto_page_break(auto=True, margin=20)
+
+    _add_cover(pdf, technology, analysis)
+    _add_overview(pdf, analysis)
+    _add_key_players(pdf, analysis, players_chart)
+    _add_use_cases(pdf, analysis, use_case_chart)
+    _add_strategic_outlook(pdf, analysis)
+
+    safe_name = technology.lower().replace(" ", "_").replace("/", "_")
+    filename = f"trend_report_{safe_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.pdf"
+    filepath = os.path.join(output_dir, filename)
+    pdf.output(filepath)
+    return filepath
+
+
+def generate_comparison_pdf_report(
+    technologies: list[str],
+    analyses: list[TechAnalysisResult],
+    output_dir: str,
+) -> str:
+    """Generate a side-by-side comparison PDF and return its path."""
+    if len(technologies) != len(analyses):
+        raise ValueError("technologies and analyses must have the same length")
+    os.makedirs(output_dir, exist_ok=True)
+
+    pdf = _TrendReportPDF(title="Tech Comparison Report")
+    pdf.set_auto_page_break(auto=True, margin=20)
+
+    # --- Cover ---
+    pdf.add_page()
+    pdf.ln(40)
+    pdf.set_font("Helvetica", "B", 22)
+    pdf.set_text_color(13, 115, 119)
+    pdf.multi_cell(0, 12, _sanitize("Technology Comparison Report"), align="C")
+    pdf.ln(4)
+    pdf.set_font("Helvetica", "", 13)
+    pdf.set_text_color(80, 80, 80)
+    pdf.multi_cell(0, 7, _sanitize(" vs ".join(technologies)), align="C")
+    pdf.set_text_color(0, 0, 0)
+
+    # --- Per-technology sections ---
+    for tech, analysis in zip(technologies, analyses):
+        pdf.add_page()
+        _heading(pdf, tech, size=16)
+        _heading(pdf, "Executive Summary", size=12)
+        _paragraph(pdf, analysis.executive_summary)
+        _heading(pdf, "Maturity", size=12)
+        _paragraph(pdf, analysis.maturity_assessment)
+        _heading(pdf, "Key Players", size=12)
+        _bullets(pdf, [f"{p.name} - {p.focus_area}" for p in analysis.key_players])
+        _heading(pdf, "Top Use Cases", size=12)
+        _bullets(pdf, [f"{u.title} ({u.impact_level}) - {u.industry}" for u in analysis.use_cases])
+        _heading(pdf, "Strengths", size=12)
+        _bullets(pdf, analysis.strengths)
+        _heading(pdf, "Limitations", size=12)
+        _bullets(pdf, analysis.limitations)
+
+    safe_techs = "_vs_".join(t.lower().replace(" ", "_") for t in technologies)
+    filename = f"comparison_{safe_techs}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.pdf"
+    filepath = os.path.join(output_dir, filename)
+    pdf.output(filepath)
+    return filepath


### PR DESCRIPTION
## Summary

- New `utils/pdf_report_generator.py` with `generate_pdf_report` and `generate_comparison_pdf_report` (fpdf2, Helvetica, latin-1 `_sanitize` helper for German umlauts / EUR / smart quotes)
- PDF section layout mirrors the DOCX: cover with executive summary, technology overview / maturity / market landscape, key players with chart, use cases with impact-coloured tags and chart, strategic outlook with strengths / limitations / drivers / barriers / trends / risks
- New CLI flag `--format {docx,pdf,both}` (default `docx`, backward compatible)
- `TechTrendOrchestrator.run / run_comparison / run_with_mock / run_comparison_with_mock` now accept `format=` and return `list[str]` of generated paths
- `fpdf2>=2.7.0` added to `requirements.txt`
- 16 new tests bring the suite from 76 to 92

Closes #13

## Test plan

- [x] All 92 backend tests pass (`pytest -q`)
- [x] Existing DOCX flow unchanged, same return shape via `[0]` access
- [x] Sanitization covers em-dash, smart quotes, bullet, ellipsis, German umlauts, EUR sign
- [ ] Manual: `python main.py "Quantum Computing" --dry-run --format both` produces both files in `output/`
